### PR TITLE
improve docs for MakePublicKey to state mutation of privateKey

### DIFF
--- a/ed25519.go
+++ b/ed25519.go
@@ -35,12 +35,14 @@ func GenerateKey(rand io.Reader) (publicKey *[PublicKeySize]byte, privateKey *[P
 	return
 }
 
-// MakePublicKey makes a publicKey from the first half of privateKey.
+// MakePublicKey makes a publicKey from the first 32 bytes
+// of privateKey, and at the end mutates privateKey setting
+// its first 32 bytes to those of the generated publicKey.
 func MakePublicKey(privateKey *[PrivateKeySize]byte) (publicKey *[PublicKeySize]byte) {
-	publicKey = new([32]byte)
+	publicKey = new([PublicKeySize]byte)
 
 	h := sha512.New()
-	h.Write(privateKey[:32])
+	h.Write(privateKey[:PublicKeySize])
 	digest := h.Sum(nil)
 
 	digest[0] &= 248
@@ -48,12 +50,12 @@ func MakePublicKey(privateKey *[PrivateKeySize]byte) (publicKey *[PublicKeySize]
 	digest[31] |= 64
 
 	var A edwards25519.ExtendedGroupElement
-	var hBytes [32]byte
+	var hBytes [PublicKeySize]byte
 	copy(hBytes[:], digest)
 	edwards25519.GeScalarMultBase(&A, &hBytes)
 	A.ToBytes(publicKey)
 
-	copy(privateKey[32:], publicKey[:])
+	copy(privateKey[PublicKeySize:], publicKey[:])
 	return
 }
 


### PR DESCRIPTION
MakePublicKey takes in a privateKey and mutates it setting
the first 32 bytes to those original 32 bytes used to
generate the publicKey.
This wasn't made clear in the comments and required digging
into the actual implementation when I was advocating for
https://github.com/tendermint/go-crypto/issues/31.
I noticed that in crypto
https://github.com/tendermint/go-crypto/blob/1bc8de4caa844f8b64c120e65b047898f22b7f3e/priv_key.go#L99-L114

there was an unexplained call to ed25519.MakePublicKey nor were
there any comments to explain that.