### PR TITLE
Add a verify method that also takes an uncompressed public key

### DIFF
--- a/ed25519_test.go
+++ b/ed25519_test.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agl/ed25519/edwards25519"
+	"github.com/tendermint/ed25519/edwards25519"
 )
 
 type zeroReader struct{}


### PR DESCRIPTION
Supercedes #7. Commit is (cherry picked from commit 2ab46c56cd4957d3e0060ef46d50a6341fcd379d) in #7.

A verification method using the uncompressed pubkey is useful for the proof of stake use case, since we often validate multiple signatures from the same public key. Based off of the numbers in the official Ed25519 paper, the function with the uncompressed pubkey should save about 10% of the computation time.