### PR TITLE
Unroll FeZero, FeOne

### DIFF
--- a/ed25519_test.go
+++ b/ed25519_test.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agl/ed25519/edwards25519"
+	"github.com/tendermint/ed25519/edwards25519"
 )
 
 type zeroReader struct{}

--- a/edwards25519/edwards25519.go
+++ b/edwards25519/edwards25519.go
@@ -19,12 +19,34 @@ type FieldElement [10]int32
 var zero FieldElement
 
 func FeZero(fe *FieldElement) {
-	copy(fe[:], zero[:])
+	// Unrolled version of:
+	// copy(fe[:], zero[:])
+	fe[0] = 0
+	fe[1] = 0
+	fe[2] = 0
+	fe[3] = 0
+	fe[4] = 0
+	fe[5] = 0
+	fe[6] = 0
+	fe[7] = 0
+	fe[8] = 0
+	fe[9] = 0
 }
 
 func FeOne(fe *FieldElement) {
-	FeZero(fe)
+	// Unrolled version of
+	// FeZero(fe)
+	// fe[0] = 1
 	fe[0] = 1
+	fe[1] = 0
+	fe[2] = 0
+	fe[3] = 0
+	fe[4] = 0
+	fe[5] = 0
+	fe[6] = 0
+	fe[7] = 0
+	fe[8] = 0
+	fe[9] = 0
 }
 
 func FeAdd(dst, a, b *FieldElement) {


### PR DESCRIPTION
This unrolls FeZero and FeOne. This doesn't change the output of the functions, but increases its speed:
```
$ benchcmp old.txt new.txt
benchmark                    old ns/op     new ns/op     delta
BenchmarkKeyGeneration-8     100659        99175         -1.47%
BenchmarkSigning-8           102219        100941        -1.25%
BenchmarkVerification-8      278957        275965        -1.07%
BenchmarkKeyGeneration-8     120965        119236        -1.43%
BenchmarkMap-8               36722         36478         -0.66%
```

The idea was taken from https://github.com/agl/ed25519/pull/11